### PR TITLE
Fix SDL2 build on Mac OS X.

### DIFF
--- a/include/frontends/sdl2/frontend.h
+++ b/include/frontends/sdl2/frontend.h
@@ -3,6 +3,10 @@
 
 #include "frontends/sdl2/sdl_inc.h"
 
+#if defined(HAVE_MACH_CLOCK_H)
+#	undef bool
+typedef _Bool bool;
+#endif
 
 typedef struct sdl2_video_data_t
 {


### PR DESCRIPTION
I'm not sure if this is appropriate for master or if we should find a better way.

Original commit description follows…

SDL2, on Mac OS X only, does some really bizarre fucko shit with bools.
Like, there's no other way to describe it.

This fixes it with a stupid yet hilarious hack involving checking if we
have mach/clock.h in a module we don't use it in just to check if OS X
is present, since we don't currently HAVE a platform definition for OS
X, it's "just POSIX".

It Just Werks®, right?